### PR TITLE
Parameter-based Ramp Insertion

### DIFF
--- a/MCFR_HyS_BOP.mo
+++ b/MCFR_HyS_BOP.mo
@@ -500,17 +500,18 @@ package MCFR_HyS_BOP
 // These next two are optional and not currently used. They attempt to include some complexity of htc changing due to flow rate turbulence
 //hApn_PHX = hApnNom_PHX*(0.8215*primaryFF.FF^6 - 4.108*primaryFF.FF^5 + 7.848*primaryFF.FF^4 - 7.165*primaryFF.FF^3 + 3.004*primaryFF.FF^2 + 0.5903*primaryFF.FF + 0.008537);
 //hAsn_PHX = hAsnNom_PHX*(0.8215*secondaryFF.FF^6 - 4.108*secondaryFF.FF^5 + 7.848*secondaryFF.FF^4 - 7.165*secondaryFF.FF^3 + 3.004*secondaryFF.FF^2 + 0.5903*secondaryFF.FF + 0.008537);
-      m_PN1_PHX*cP_pFluid_PHX*der(T_PN1_PHX) = m_dot_pFluid_PHX*cP_pFluid_PHX*(T_in_pFluid_PHX.T - T_PN1_PHX) - hApn_PHX*(T_PN1_PHX - T_TN1_PHX) + P_decay.Q*m_PN1_PHX;
-      m_PN2_PHX*cP_pFluid_PHX*der(T_PN2_PHX) = m_dot_pFluid_PHX*cP_pFluid_PHX*(T_PN1_PHX - T_PN2_PHX) - hApn_PHX*(T_PN1_PHX - T_TN1_PHX) + P_decay.Q*m_PN2_PHX;
-      m_PN3_PHX*cP_pFluid_PHX*der(T_PN3_PHX) = m_dot_pFluid_PHX*cP_pFluid_PHX*(T_PN2_PHX - T_PN3_PHX) - hApn_PHX*(T_PN3_PHX - T_TN2_PHX) + P_decay.Q*m_PN3_PHX;
-      m_PN4_PHX*cP_pFluid_PHX*der(T_PN4_PHX) = m_dot_pFluid_PHX*cP_pFluid_PHX*(T_PN3_PHX - T_PN4_PHX) - hApn_PHX*(T_PN3_PHX - T_TN2_PHX) + P_decay.Q*m_PN4_PHX;
-      m_TN1_PHX*cP_Tube_PHX*der(T_TN1_PHX) = 2*hApn_PHX*(T_PN1_PHX - T_TN1_PHX) - 2*hAsn_PHX*(T_TN1_PHX - T_SN3_PHX);
-      m_TN2_PHX*cP_Tube_PHX*der(T_TN2_PHX) = 2*hApn_PHX*(T_PN3_PHX - T_TN2_PHX) - 2*hAsn_PHX*(T_TN2_PHX - T_SN1_PHX);
-      m_SN1_PHX*cP_sFluid_PHX*der(T_SN1_PHX) = m_dot_sFluid_PHX*cP_sFluid_PHX*(T_in_sFluid_PHX.T - T_SN1_PHX) + hAsn_PHX*(T_TN2_PHX - T_SN1_PHX);
-      m_SN2_PHX*cP_sFluid_PHX*der(T_SN2_PHX) = m_dot_sFluid_PHX*cP_sFluid_PHX*(T_SN1_PHX - T_SN2_PHX) + hAsn_PHX*(T_TN2_PHX - T_SN1_PHX);
-      m_SN3_PHX*cP_sFluid_PHX*der(T_SN3_PHX) = m_dot_sFluid_PHX*cP_sFluid_PHX*(T_SN2_PHX - T_SN3_PHX) + hAsn_PHX*(T_TN1_PHX - T_SN3_PHX);
-      m_SN4_PHX*cP_sFluid_PHX*der(T_SN4_PHX) = m_dot_sFluid_PHX*cP_sFluid_PHX*(T_SN3_PHX - T_SN4_PHX) + hAsn_PHX*(T_TN1_PHX - T_SN3_PHX);
-      T_out_sFluid_PHX.T = delay(T_SN4_PHX, varTauPHXtoSHX, 5000); // Delay for transport time
+      m_PN1_PHX*cP_pFluid_PHX*der(T_PN1_PHX) = m_dot_pFluid_PHX*cP_pFluid_PHX*(T_in_pFluid_PHX.T - T_PN1_PHX) - hApn_PHX*((T_PN1_PHX + T_PN2_PHX)/2 - T_TN1_PHX) + P_decay.Q*m_PN1_PHX;
+      m_PN2_PHX*cP_pFluid_PHX*der(T_PN2_PHX) = m_dot_pFluid_PHX*cP_pFluid_PHX*(T_PN1_PHX - T_PN2_PHX) - hApn_PHX*((T_PN1_PHX + T_PN2_PHX)/2 - T_TN1_PHX) + P_decay.Q*m_PN2_PHX;
+      m_PN3_PHX*cP_pFluid_PHX*der(T_PN3_PHX) = m_dot_pFluid_PHX*cP_pFluid_PHX*(T_PN2_PHX - T_PN3_PHX) - hApn_PHX*((T_PN3_PHX + T_PN4_PHX)/2 - T_TN2_PHX) + P_decay.Q*m_PN3_PHX;
+      m_PN4_PHX*cP_pFluid_PHX*der(T_PN4_PHX) = m_dot_pFluid_PHX*cP_pFluid_PHX*(T_PN3_PHX - T_PN4_PHX) - hApn_PHX*((T_PN3_PHX + T_PN4_PHX)/2 - T_TN2_PHX) + P_decay.Q*m_PN4_PHX;
+      m_TN1_PHX*cP_Tube_PHX*der(T_TN1_PHX) = 2*hApn_PHX*((T_PN1_PHX + T_PN2_PHX)/2 - T_TN1_PHX) - 2*hAsn_PHX*(T_TN1_PHX - (T_SN3_PHX + T_SN4_PHX)/2);
+      m_TN2_PHX*cP_Tube_PHX*der(T_TN2_PHX) = 2*hApn_PHX*((T_PN3_PHX + T_PN4_PHX)/2 - T_TN2_PHX) - 2*hAsn_PHX*(T_TN2_PHX - (T_SN1_PHX + T_SN2_PHX)/2);
+      m_SN1_PHX*cP_sFluid_PHX*der(T_SN1_PHX) = m_dot_sFluid_PHX*cP_sFluid_PHX*(T_in_sFluid_PHX.T - T_SN1_PHX) + hAsn_PHX*(T_TN2_PHX - (T_SN1_PHX + T_SN2_PHX)/2);
+      m_SN2_PHX*cP_sFluid_PHX*der(T_SN2_PHX) = m_dot_sFluid_PHX*cP_sFluid_PHX*(T_SN1_PHX - T_SN2_PHX) + hAsn_PHX*(T_TN2_PHX - (T_SN1_PHX + T_SN2_PHX)/2);
+      m_SN3_PHX*cP_sFluid_PHX*der(T_SN3_PHX) = m_dot_sFluid_PHX*cP_sFluid_PHX*(T_SN2_PHX - T_SN3_PHX) + hAsn_PHX*(T_TN1_PHX - (T_SN3_PHX + T_SN4_PHX)/2);
+      m_SN4_PHX*cP_sFluid_PHX*der(T_SN4_PHX) = m_dot_sFluid_PHX*cP_sFluid_PHX*(T_SN3_PHX - T_SN4_PHX) + hAsn_PHX*(T_TN1_PHX - (T_SN3_PHX + T_SN4_PHX)/2);
+      T_out_sFluid_PHX.T = delay(T_SN4_PHX, varTauPHXtoSHX, 5000);
+    // Delay for transport time
       m_pipe*cP_pFluid_PHX*der(Pipe_Temp) = m_dot_pFluid_PHX*cP_pFluid_PHX*(T_PN4_PHX - Pipe_Temp) + P_decay.Q*m_pipe;
       T_out_pFluid_PHX.T = delay(Pipe_Temp, varTauPHXtoCore, 5000);
       P_primaryLoop = m_dot_pFluid_PHX*cP_pFluid_PHX*(T_in_pFluid_PHX.T - T_PN4_PHX) + P_decay.Q*4*m_PN1_PHX;
@@ -628,16 +629,18 @@ package MCFR_HyS_BOP
       hApn_SHX = hApnNom_SHX;
       hAsn_SHX = hAsnNom_SHX;
       T_in_sFluid_SHX = (T_in_sFluid_OTSG.T + T_in_sFluid_HyS.T)/2;
-      m_PN1_SHX*cP_pFluid_SHX*der(T_PN1_SHX) = m_dot_pFluid_SHX*cP_pFluid_SHX*(T_in_pFluid_SHX.T - T_PN1_SHX) - hApn_SHX*(T_PN1_SHX - T_TN1_SHX);
-      m_PN2_SHX*cP_pFluid_SHX*der(T_PN2_SHX) = m_dot_pFluid_SHX*cP_pFluid_SHX*(T_PN1_SHX - T_PN2_SHX) - hApn_SHX*(T_PN1_SHX - T_TN1_SHX);
-      m_PN3_SHX*cP_pFluid_SHX*der(T_PN3_SHX) = m_dot_pFluid_SHX*cP_pFluid_SHX*(T_PN2_SHX - T_PN3_SHX) - hApn_SHX*(T_PN3_SHX - T_TN2_SHX);
-      m_PN4_SHX*cP_pFluid_SHX*der(T_PN4_SHX) = m_dot_pFluid_SHX*cP_pFluid_SHX*(T_PN3_SHX - T_PN4_SHX) - hApn_SHX*(T_PN3_SHX - T_TN2_SHX);
-      m_TN1_SHX*cP_Tube_SHX*der(T_TN1_SHX) = 2*hApn_SHX*(T_PN1_SHX - T_TN1_SHX) - 2*hAsn_SHX*(T_TN1_SHX - T_SN3_SHX);
-      m_TN2_SHX*cP_Tube_SHX*der(T_TN2_SHX) = 2*hApn_SHX*(T_PN3_SHX - T_TN2_SHX) - 2*hAsn_SHX*(T_TN2_SHX - T_SN1_SHX);
-      m_SN1_SHX*cP_sFluid_SHX*der(T_SN1_SHX) = m_dot_sFluid_SHX*cP_sFluid_SHX*(T_in_sFluid_SHX - T_SN1_SHX) + hAsn_SHX*(T_TN2_SHX - T_SN1_SHX);
-      m_SN2_SHX*cP_sFluid_SHX*der(T_SN2_SHX) = m_dot_sFluid_SHX*cP_sFluid_SHX*(T_SN1_SHX - T_SN2_SHX) + hAsn_SHX*(T_TN2_SHX - T_SN1_SHX);
-      m_SN3_SHX*cP_sFluid_SHX*der(T_SN3_SHX) = m_dot_sFluid_SHX*cP_sFluid_SHX*(T_SN2_SHX - T_SN3_SHX) + hAsn_SHX*(T_TN1_SHX - T_SN3_SHX);
-      m_SN4_SHX*cP_sFluid_SHX*der(T_SN4_SHX) = m_dot_sFluid_SHX*cP_sFluid_SHX*(T_SN3_SHX - T_SN4_SHX) + hAsn_SHX*(T_TN1_SHX - T_SN3_SHX);
+      m_PN1_SHX*cP_pFluid_SHX*der(T_PN1_SHX) = m_dot_pFluid_SHX*cP_pFluid_SHX*(T_in_pFluid_SHX.T - T_PN1_SHX) - hApn_SHX*((T_PN1_SHX + T_PN2_SHX)/2 - T_TN1_SHX);
+      m_PN2_SHX*cP_pFluid_SHX*der(T_PN2_SHX) = m_dot_pFluid_SHX*cP_pFluid_SHX*(T_PN1_SHX - T_PN2_SHX) - hApn_SHX*((T_PN1_SHX + T_PN2_SHX)/2 - T_TN1_SHX);
+      m_PN3_SHX*cP_pFluid_SHX*der(T_PN3_SHX) = m_dot_pFluid_SHX*cP_pFluid_SHX*(T_PN2_SHX - T_PN3_SHX) - hApn_SHX*((T_PN3_SHX + T_PN4_SHX)/2 - T_TN2_SHX);
+      m_PN4_SHX*cP_pFluid_SHX*der(T_PN4_SHX) = m_dot_pFluid_SHX*cP_pFluid_SHX*(T_PN3_SHX - T_PN4_SHX) - hApn_SHX*((T_PN3_SHX + T_PN4_SHX)/2 - T_TN2_SHX);
+      m_TN1_SHX*cP_Tube_SHX*der(T_TN1_SHX) = 2*hApn_SHX*((T_PN1_SHX + T_PN2_SHX)/2 - T_TN1_SHX) - 2*hAsn_SHX*(T_TN1_SHX - (T_SN3_SHX + T_SN4_SHX)/2);
+      m_TN2_SHX*cP_Tube_SHX*der(T_TN2_SHX) = 2*hApn_SHX*((T_PN3_SHX + T_PN4_SHX)/2 - T_TN2_SHX) - 2*hAsn_SHX*(T_TN2_SHX - (T_SN1_SHX + T_SN2_SHX)/2);
+      m_SN1_SHX*cP_sFluid_SHX*der(T_SN1_SHX) = m_dot_sFluid_SHX*cP_sFluid_SHX*(T_in_sFluid_SHX - T_SN1_SHX) + hAsn_SHX*(T_TN2_SHX - (T_SN1_SHX + T_SN2_SHX)/2);
+      m_SN2_SHX*cP_sFluid_SHX*der(T_SN2_SHX) = m_dot_sFluid_SHX*cP_sFluid_SHX*(T_SN1_SHX - T_SN2_SHX) + hAsn_SHX*(T_TN2_SHX - (T_SN1_SHX + T_SN2_SHX)/2);
+      m_SN3_SHX*cP_sFluid_SHX*der(T_SN3_SHX) = m_dot_sFluid_SHX*cP_sFluid_SHX*(T_SN2_SHX - T_SN3_SHX) + hAsn_SHX*(T_TN1_SHX - (T_SN3_SHX + T_SN4_SHX)/2);
+      m_SN4_SHX*cP_sFluid_SHX*der(T_SN4_SHX) = m_dot_sFluid_SHX*cP_sFluid_SHX*(T_SN3_SHX - T_SN4_SHX) + hAsn_SHX*(T_TN1_SHX - (T_SN3_SHX + T_SN4_SHX)/2);
+    
+    
       T_out_pFluid_SHX.T = delay(T_PN4_SHX, varTauSHXtoPHX, 5000);
       T_out_sFluid_SHX.T = delay(T_SN4_SHX, varTauSHXtoOTSG, 5000);
       P_SecondaryLoop = m_dot_pFluid_SHX*cP_pFluid_SHX*(T_in_pFluid_SHX.T - T_PN4_SHX);
@@ -653,14 +656,8 @@ package MCFR_HyS_BOP
       // Parameter declaration
       parameter MCFR_HyS_BOP.Units.Density rho_hitec = 1680; // From http://www.coal2nuclear.com/MSR%20-%20HITEC%20Heat%20Transfer%20Salt.pdf
       parameter MCFR_HyS_BOP.Units.Density rho_tube = 8425.712;
-      parameter MCFR_HyS_BOP.Units.Density rho_SC = 778.8648; // Density of subcooled fluid in neighbor node to saturated boiling
-      parameter MCFR_HyS_BOP.Units.Density rho_sh = 45.05219; // Density of the superheated steam
       parameter MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_hitec = 0.00154912; // Hitec salt specific heat [MJ/(kg*C)]
       parameter MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_Tube_OTSG = 456.056e-6; // OTSG Tubing specific heat [MJ/(kg*C)]
-      parameter MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_SH1 = 0.002573333673413; // Specific heat approximation for the steam outlet
-      parameter MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_SH2 = 0.003687517297276; // Specific heat approximation for the steam between boiling and outlet
-      parameter MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_fdw = 0.004393935709417; // Specific heat approximation of subcooled fluid at OTSG inlet
-      parameter MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_SC = 0.005121564867136; // Specific heat of subcooled fluid in neighbor node to saturated boiling
       parameter MCFR_HyS_BOP.Units.MassFlowRate m_dot_hitecNom;// = 12910.56;//3379; // Hitec salt nominal flow rate
       parameter MCFR_HyS_BOP.Units.MassFlowRate m_dot_fdwNom = 1.925004320027648e+02;             // Feedwater nominal flow rate
       parameter MCFR_HyS_BOP.Units.Convection h_pw = 9101.343578935E-6; // OTSG primary side to tubes heat transfer coefficient [MJ/(s*C)]
@@ -731,6 +728,15 @@ package MCFR_HyS_BOP
       MCFR_HyS_BOP.Units.Length L_sh;
       MCFR_HyS_BOP.Units.Mass M_sh;
       MCFR_HyS_BOP.Units.ReactorPower P_OTSG_Primary;
+      
+      Water.ThermodynamicState fdw, SC2, SH2, SH1;
+      MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_fdw;
+      MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_SC2;
+      MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_SH2;
+      MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_SH1;
+      MCFR_HyS_BOP.Units.Density rho_SC2;
+      MCFR_HyS_BOP.Units.Density rho_SH1;
+      
       // Connections to other modules
       input MCFR_HyS_BOP.Connectors.Temp_In T_in_hitec_OTSG annotation(
         Placement(visible = true, transformation(origin = {-176, 30}, extent = {{-20, -20}, {20, 20}}, rotation = 0), iconTransformation(origin = {-176, 30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
@@ -769,8 +775,21 @@ package MCFR_HyS_BOP
       L_b = L_b_initial;
       L_sh = L_sh_initial;
       P_stm.P = P_setpoint;
-      M_sh = A_flow * rho_sh * L_sh_initial;
+      rho_SH1 = Water.density_pT(P_stm.P*1e6, T_SH1.T + 273.15);
+      M_sh = A_flow * rho_SH1 * L_sh_initial;
     equation
+      fdw = Water.setState_pT(P_stm.P*1e6, T_fdw.T + 273.15);
+      SC2 = Water.setState_pT(P_stm.P*1e6, T_SC2 + 273.15);
+      SH2 = Water.setState_pT(P_stm.P*1e6, T_SH2 + 273.15);
+      SH1 = Water.setState_pT(P_stm.P*1e6, T_SH1.T + 273.15);
+      
+      cP_fdw = Water.specificHeatCapacityCp(fdw)*1e-6;
+      cP_SC2 = Water.specificHeatCapacityCp(SC2)*1e-6;
+      cP_SH2 = Water.specificHeatCapacityCp(SH2)*1e-6;
+      cP_SH1 = Water.specificHeatCapacityCp(SH1)*1e-6;
+      rho_SC2 = Water.density_pT(P_stm.P*1e6, T_SC2 + 273.15);
+      rho_SH1 = Water.density_pT(P_stm.P*1e6, T_SH1.T + 273.15);
+      
       m_dot_hitec = m_dot_hitecNom*tertiaryFF.FF;
       varTauOTSGtoSHX = tauOTSGtoSHX/tertiaryFF.FF;
 // Primary Side Nodes
@@ -794,7 +813,7 @@ package MCFR_HyS_BOP
     der(T_SH2)*(M_sh*0.5*cP_SH2) = (h_wsh*(N_tubes*pi*D_outer*L_sh*0.5)*(T_TN2 - T_SH2) + (m_dot_B*cP_SH2*(T_sat - T_SH2)) + (A_flow*L_sh*0.5 - dHs_dPs)*der(P_stm.P));
 // Superheated steam node #2 temperature eqn
       T_sat = X_5 + K_5*P_stm.P; // Saturated boiling temp eqn
-        der(T_SC2) = ((h_wsc*(N_tubes*pi*D_outer*L_sc*0.5)*(T_TN6-T_SC2) + (cP_fdw*m_dot_fdw.mdot*T_fdw.T) - cP_SC*((m_dot_fdw.mdot+m_dot_SC)*0.5*T_SC2) + A_flow*L_sc*0.5*der(P_stm.P)) * (2/(A_flow * rho_SC *cP_SC)) - T_SC2*der(L_sc))*(1/(L_sc)); // Subcooled fluid node temperature eqn
+        der(T_SC2) = ((h_wsc*(N_tubes*pi*D_outer*L_sc*0.5)*(T_TN6-T_SC2) + (cP_fdw*m_dot_fdw.mdot*T_fdw.T) - cP_SC2*((m_dot_fdw.mdot+m_dot_SC)*0.5*T_SC2) + A_flow*L_sc*0.5*der(P_stm.P)) * (2/(A_flow * rho_SC2 *cP_SC2)) - T_SC2*der(L_sc))*(1/(L_sc)); // Subcooled fluid node temperature eqn
 // Secondary side pressure:
       der(P_stm.P)*A_flow*L_sh = ((Z_ss*R_ugc)*(der(M_sh)*(T_SH1.T + T_SH2) + M_sh*(der(T_SH1.T) + der(T_SH2)))/(2*MM_stm)) - (P_stm.P*A_flow*der(L_sh)); // Secondary side pressure. T_sh1 is OTSG outlet. Assumption: P_subcooled = P_saturatedboiling = P_superheated
 //der(P_stm.P)*A_flow*L_sh = ((Z_ss*R_ugc)*(der(M_sh)*(T_SH2) + M_sh*(der(T_SH2)))/(MM_stm)) - (P_stm.P*A_flow*der(L_sh)); //Alternative method
@@ -803,12 +822,12 @@ package MCFR_HyS_BOP
 //=======
 // Density, length, and mass flow rates:
       rho_b = 25.884875705 + 12.835*P_stm.P; // Two-phase boiling density eqn. See Singh_2020 (https://www.sciencedirect.com/science/article/pii/S0029549319304881)
-      der(L_sc) = (1/(A_flow * 0.5 * rho_SC * cP_SC * (T_SC2 - T_sat))) * (h_wsc * N_tubes * pi * D_outer * L_sc * 0.5 * (T_TN5 - T_sat) + cP_SC * (m_dot_fdw.mdot * T_SC2 - (m_dot_fdw.mdot + m_dot_SC) * 0.5 * T_sat) + A_flow * L_sc * 0.5 * (K_sc * cP_SC * (T_SC2 - 2 * T_sat) - 1) * der(P_stm.P) - (A_flow * rho_SC * cP_SC * K_1 * L_sc * 0.5 * der(P_stm.P))); // Subcooled domain length eqn
+      der(L_sc) = (1/(A_flow * 0.5 * rho_SC2 * cP_SC2 * (T_SC2 - T_sat))) * (h_wsc * N_tubes * pi * D_outer * L_sc * 0.5 * (T_TN5 - T_sat) + cP_SC2 * (m_dot_fdw.mdot * T_SC2 - (m_dot_fdw.mdot + m_dot_SC) * 0.5 * T_sat) + A_flow * L_sc * 0.5 * (K_sc * cP_SC2 * (T_SC2 - 2 * T_sat) - 1) * der(P_stm.P) - (A_flow * rho_SC2 * cP_SC2 * K_1 * L_sc * 0.5 * der(P_stm.P))); // Subcooled domain length eqn
       der(L_b)*A_flow*rho_b = m_dot_SC - m_dot_B - (A_flow*L_b*K_b*der(P_stm.P)); // Boiling domain length eqn
       L_sh = L_OTSG - L_b - L_sc; // Total OTSG length eqn
 //  der(L_sh) = -der(L_b) - der(L_sc); // Superheated domain length eqn
       m_dot_SH.mdot = m_dot_fdw.mdot * P_stm.P / P_setpoint; // Flow rate out of superheated domain (and OTSG)
-      m_dot_SC = m_dot_fdw.mdot - (rho_SC*A_flow*der(L_sc)) - (A_flow*L_sc*K_sc*der(P_stm.P)); // Flow rate out of subcooled domain
+      m_dot_SC = m_dot_fdw.mdot - (rho_SC2*A_flow*der(L_sc)) - (A_flow*L_sc*K_sc*der(P_stm.P)); // Flow rate out of subcooled domain
       m_dot_B = (h_wb*(N_tubes*pi*D_outer*L_b)*(T_TN3*0.5 + T_TN4*0.5 - T_sat))/(X_4 + K_4*P_stm.P); // Flow rate out of boiling domain
 //  m_dot_SC = 1.925004320027648e+02;
 //  m_dot_B = 1.925004320027648e+02;

--- a/MCFR_HyS_BOP.mo
+++ b/MCFR_HyS_BOP.mo
@@ -19,7 +19,7 @@ package MCFR_HyS_BOP
       Placement(visible = true, transformation(origin = {-1181, -471}, extent = {{-463, -463}, {463, 463}}, rotation = 0)));
     MCFR_HyS_BOP.Nuclear.Poisons Poisons(lam_bubble = 0.005) annotation(
       Placement(visible = true, transformation(origin = {-1265, -1015}, extent = {{-555, -555}, {555, 555}}, rotation = 0)));
-    MCFR_HyS_BOP.Nuclear.ReactivityFeedback ReactivityFeedback(a_F = -4.4376e-05, a_R = 0.1164e-05, step_mag = -185*1e-5, omega = 0.1, sin_mag = 1*1e-5, ramp_rate = -1e-5, ramp_low = 0.4, stepInsertionTime = 500000000, sinInsertionTime = 88888888, rampInsertionTime = 500000000) annotation(
+    MCFR_HyS_BOP.Nuclear.ReactivityFeedback ReactivityFeedback(a_F = -4.4376e-05, a_R = 0.1164e-05, step_mag = -185*1e-5, omega = 0.1, sin_mag = 1*1e-5, ramp_rate = 11e-5, ramp_mag = 600e-5, stepInsertionTime = 500000000, sinInsertionTime = 88888888, rampInsertionTime = 500000000) annotation(
       Placement(visible = true, transformation(origin = {-519, -1063}, extent = {{545, -545}, {-545, 545}}, rotation = 0)));
     MCFR_HyS_BOP.Pumps.PrimaryLoopPump PLP(freeConvectionFF = 0.125, primaryPumpK = 0.092, tripPrimaryPump = 5000000) annotation(
       Placement(visible = true, transformation(origin = {364, 566}, extent = {{-262, -262}, {262, 262}}, rotation = 0)));
@@ -107,7 +107,7 @@ package MCFR_HyS_BOP
       parameter MCFR_HyS_BOP.Units.PrecursorDecayConstant lam[6];
       parameter MCFR_HyS_BOP.Units.DelayedNeutronFrac beta[6];
       parameter MCFR_HyS_BOP.Units.ResidentTime tauCoreNom = 7.028; // Avg travel time within core
-      parameter MCFR_HyS_BOP.Units.ResidentTime tauLoopNom = 7.028; // Avg travel time from core outlet to inlet
+      parameter MCFR_HyS_BOP.Units.ResidentTime tauLoopNom = 7.028;       // Avg travel time from core outlet to inlet
       //Variable declaration
       MCFR_HyS_BOP.Units.ResidentTime varTauCore;
       MCFR_HyS_BOP.Units.ResidentTime varTauLoop;
@@ -223,7 +223,7 @@ package MCFR_HyS_BOP
       parameter MCFR_HyS_BOP.Units.MacroAbsorptionCrossSection Sig_f = 0.00129788; // Fission cross section of fuel
       parameter MCFR_HyS_BOP.Units.MacroAbsorptionCrossSection Sig_a = 0.00302062; // Absorption cross section of fuel
       parameter MCFR_HyS_BOP.Units.NominalNeutronFlux phi_0 = 3.51513E+14; // Flux density in core
-      parameter MCFR_HyS_BOP.Units.OffgasRemovalRate lam_bubble; // Removal rate of fission gases via bubble removal. See Dunkle_2023 "Effect of xenon removal rate on load following in high power thermal spectrum Molten-Salt Reactors (MSRs)" for more info.
+      parameter MCFR_HyS_BOP.Units.OffgasRemovalRate lam_bubble;       // Removal rate of fission gases via bubble removal. See Dunkle_2023 "Effect of xenon removal rate on load following in high power thermal spectrum Molten-Salt Reactors (MSRs)" for more info.
       //Variable declarations
       MCFR_HyS_BOP.Units.IsotopicConc I135_conc;
       MCFR_HyS_BOP.Units.IsotopicConc Xe135_conc;
@@ -267,12 +267,12 @@ package MCFR_HyS_BOP
       parameter MCFR_HyS_BOP.Units.Reactivity step_mag;
       parameter MCFR_HyS_BOP.Units.Frequency omega;
       parameter MCFR_HyS_BOP.Units.Reactivity sin_mag;
-      parameter MCFR_HyS_BOP.Units.Reactivity ramp_rate;
+      parameter MCFR_HyS_BOP.Units.ReactivityRate ramp_rate;
+      parameter MCFR_HyS_BOP.Units.Reactivity ramp_mag;
       parameter MCFR_HyS_BOP.Units.Reactivity dollar = 0.007407352; // Unused in current version. Can be used for reactivity in cents
       parameter MCFR_HyS_BOP.Units.InitiationTime stepInsertionTime;
       parameter MCFR_HyS_BOP.Units.InitiationTime sinInsertionTime;
       parameter MCFR_HyS_BOP.Units.InitiationTime rampInsertionTime;
-      parameter MCFR_HyS_BOP.Units.Number ramp_low;
       MCFR_HyS_BOP.Units.Reactivity FuelTempFeedbackNode1;
       MCFR_HyS_BOP.Units.Reactivity FuelTempFeedbackNode2;
       MCFR_HyS_BOP.Units.Reactivity ReflcTempFeedback;
@@ -301,7 +301,7 @@ package MCFR_HyS_BOP
     equation
       ReactExternalStep = 0 + (if time < stepInsertionTime then 0 else step_mag); // For step insertion
       ReactExternalSin = delay(sin_mag*sin(omega*time), sinInsertionTime); // For sinusoid insertion
-      ReactExternalRamp = 0 + (if (time < rampInsertionTime) then 0 else if (time < rampInsertionTime + 54.55) then (600*1e-5)*(time - rampInsertionTime)/54.55 else if (time < rampInsertionTime + 1050000) then (600*1e-5) else if (time < rampInsertionTime + 1100000) then (600*1e-5)*(rampInsertionTime + 1150000 - time)/54.55 else 0); // For ramp insertion. NOTE: The numbers will need to be changed to redesign the ramp. Would be improved by turning these into parameters.
+      ReactExternalRamp = 0 + (if (time < rampInsertionTime) then 0 else if (time > rampInsertionTime + ramp_mag / ramp_rate) then ramp_mag else ramp_rate * (time - rampInsertionTime)); //For ramp insertion
       FuelTempFeedbackNode1 = (fuelNode1.T - FuelTempSetPointNode1)*(a_F/2); 
       FuelTempFeedbackNode2 = (fuelNode2.T - FuelTempSetPointNode2)*(a_F/2);
       ReflcTempFeedback = (ReflcNode.T - ReflcTempSetPoint)*a_R;
@@ -414,11 +414,11 @@ package MCFR_HyS_BOP
       // Secondary Side node 4 mass
       parameter MCFR_HyS_BOP.Units.Mass m_pipe = 31915;
       // Mass of fluid in pipe between PHX to Core. Necessary due to decay heat present even in transport
-      parameter MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_pFluid_PHX = 0.00066065; // From Terrapower documents
+      parameter MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_pFluid_PHX = 0.00066065;       // From Terrapower documents
       // Fuel salt specific heat [MJ/(kg*C)]
-      parameter MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_Tube_PHX = 0.00057779; // specific heat capacity of tubes (MJ/(kg-C)) ORNL-TM-0728 p.20
+      parameter MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_Tube_PHX = 0.00057779;       // specific heat capacity of tubes (MJ/(kg-C)) ORNL-TM-0728 p.20
       // PHX Tubing specific heat [MJ/(kg*C)]
-      parameter MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_sFluid_PHX = 0.0011; // Secondary salt. See Dunkle_2025 "Dynamic Modeling of a Fast Spectrum Molten Salt Reactor Integrated Energy System" Table 1
+      parameter MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_sFluid_PHX = 0.0011;       // Secondary salt. See Dunkle_2025 "Dynamic Modeling of a Fast Spectrum Molten Salt Reactor Integrated Energy System" Table 1
       // Coolant salt specific heat [MJ/(kg*C)]
       parameter MCFR_HyS_BOP.Units.MassFlowRate m_dot_pFluidNom_PHX;
       // Fuel salt nominal flow rate
@@ -428,9 +428,9 @@ package MCFR_HyS_BOP
       // PHX primary side heat transfer coefficient [MJ/(s*C)]
       parameter MCFR_HyS_BOP.Units.Convection hAsnNom_PHX;
       // PHX secondary side heat transfer coefficient [MJ/(s*C)]
-      parameter MCFR_HyS_BOP.Units.ResidentTime tauPHXtoCore = 1;      //0.6887;
+      parameter MCFR_HyS_BOP.Units.ResidentTime tauPHXtoCore = 1;            //0.6887;
       // Avg travel time from PHX to pipe
-      parameter MCFR_HyS_BOP.Units.ResidentTime tauPHXtoSHX = 10;            //2.5;
+      parameter MCFR_HyS_BOP.Units.ResidentTime tauPHXtoSHX = 10;                  //2.5;
       // Avg travel time from PHX to SHX
       //parameter MCFR_HyS_BOP.Units.ResidentTime tauPipeToCore = 0.6887;
       parameter MCFR_HyS_BOP.Units.Temperature T_PN1_PHX_initial = 708.6;
@@ -534,7 +534,7 @@ package MCFR_HyS_BOP
       // SHX Tubing node 1 mass
       parameter MCFR_HyS_BOP.Units.Mass m_TN2_SHX = 4268;
       // SHX Tubing node 2 mass
-      parameter MCFR_HyS_BOP.Units.Mass m_SN1_SHX = 20460;      //20460;
+      parameter MCFR_HyS_BOP.Units.Mass m_SN1_SHX = 20460;            //20460;
       // Cold Side (Hitec salt from OTSG) node 1 mass
       parameter MCFR_HyS_BOP.Units.Mass m_SN2_SHX = 20460;
       // Cold Side (Hitec salt from OTSG) node 2 mass
@@ -542,11 +542,11 @@ package MCFR_HyS_BOP
       // Cold Side (Hitec salt from OTSG) node 3 mass
       parameter MCFR_HyS_BOP.Units.Mass m_SN4_SHX = 20460;
       // Cold Side (Hitec salt from OTSG) node 4 mass
-      parameter MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_pFluid_SHX = 0.0011; // See IES paper Table 1 for details
+      parameter MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_pFluid_SHX = 0.0011;       // See IES paper Table 1 for details
       // Fuel salt specific heat [MJ/(kg*C)]
       parameter MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_Tube_SHX = 0.00057779;
       // PHX Tubing specific heat [MJ/(kg*C)]
-      parameter MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_sFluid_SHX = 0.00154912; // Hitec salt specific heat capacity
+      parameter MCFR_HyS_BOP.Units.SpecificHeatCapacity cP_sFluid_SHX = 0.00154912;       // Hitec salt specific heat capacity
       // Coolant salt specific heat [MJ/(kg*C)]
       parameter MCFR_HyS_BOP.Units.MassFlowRate m_dot_pFluidNom_SHX;
       // Fuel salt nominal flow rate
@@ -556,9 +556,9 @@ package MCFR_HyS_BOP
       // PHX primary side heat transfer coefficient [MJ/(s*C)]
       parameter MCFR_HyS_BOP.Units.Convection hAsnNom_SHX;
       // PHX secondary side heat transfer coefficient [MJ/(s*C)]
-      parameter MCFR_HyS_BOP.Units.ResidentTime tauSHXtoPHX = 10;      //2.5
+      parameter MCFR_HyS_BOP.Units.ResidentTime tauSHXtoPHX = 10;            //2.5
       // Avg travel time from SHX to PHX
-      parameter MCFR_HyS_BOP.Units.ResidentTime tauSHXtoOTSG = 10;      //2.5
+      parameter MCFR_HyS_BOP.Units.ResidentTime tauSHXtoOTSG = 10;            //2.5
       // Avg travel time from SHX to OTSG
       parameter MCFR_HyS_BOP.Units.Temperature T_PN1_SHX_initial = 679.6;
       parameter MCFR_HyS_BOP.Units.Temperature T_PN2_SHX_initial = 670.4;
@@ -704,7 +704,7 @@ package MCFR_HyS_BOP
       parameter MCFR_HyS_BOP.Units.CompressibilityFactor Z_ss = 0.76634; // Compressibility factor at 570K and 60 atm
       parameter MCFR_HyS_BOP.Units.UniversalGasConstant R_ugc = 8.3114462e-6; // Universal gas constant [MJ/(mol*C)]
       parameter MCFR_HyS_BOP.Units.MolarMass MM_stm = 0.018; // Molar mass of steam
-      parameter MCFR_HyS_BOP.Units.Pressure P_setpoint = 12.5; // Nominal secondary side pressure [MPa]
+      parameter MCFR_HyS_BOP.Units.Pressure P_setpoint = 12.5;       // Nominal secondary side pressure [MPa]
       // Variable declaration
       MCFR_HyS_BOP.Units.ResidentTime varTauOTSGtoSHX;
       MCFR_HyS_BOP.Units.MassFlowRate m_dot_hitec;
@@ -798,9 +798,9 @@ package MCFR_HyS_BOP
 // Secondary side pressure:
       der(P_stm.P)*A_flow*L_sh = ((Z_ss*R_ugc)*(der(M_sh)*(T_SH1.T + T_SH2) + M_sh*(der(T_SH1.T) + der(T_SH2)))/(2*MM_stm)) - (P_stm.P*A_flow*der(L_sh)); // Secondary side pressure. T_sh1 is OTSG outlet. Assumption: P_subcooled = P_saturatedboiling = P_superheated
 //der(P_stm.P)*A_flow*L_sh = ((Z_ss*R_ugc)*(der(M_sh)*(T_SH2) + M_sh*(der(T_SH2)))/(MM_stm)) - (P_stm.P*A_flow*der(L_sh)); //Alternative method
- //P_stm.P = 12.5; // Default pressure. Uncomment this and comment the der(P_stm.P) eqn to set pressure constant.
+//P_stm.P = 12.5; // Default pressure. Uncomment this and comment the der(P_stm.P) eqn to set pressure constant.
 //  der(P_stm) = 0; //Alternative
-    //=======
+//=======
 // Density, length, and mass flow rates:
       rho_b = 25.884875705 + 12.835*P_stm.P; // Two-phase boiling density eqn. See Singh_2020 (https://www.sciencedirect.com/science/article/pii/S0029549319304881)
       der(L_sc) = (1/(A_flow * 0.5 * rho_SC * cP_SC * (T_SC2 - T_sat))) * (h_wsc * N_tubes * pi * D_outer * L_sc * 0.5 * (T_TN5 - T_sat) + cP_SC * (m_dot_fdw.mdot * T_SC2 - (m_dot_fdw.mdot + m_dot_SC) * 0.5 * T_sat) + A_flow * L_sc * 0.5 * (K_sc * cP_SC * (T_SC2 - 2 * T_sat) - 1) * der(P_stm.P) - (A_flow * rho_SC * cP_SC * K_1 * L_sc * 0.5 * der(P_stm.P))); // Subcooled domain length eqn
@@ -810,8 +810,8 @@ package MCFR_HyS_BOP
       m_dot_SH.mdot = m_dot_fdw.mdot * P_stm.P / P_setpoint; // Flow rate out of superheated domain (and OTSG)
       m_dot_SC = m_dot_fdw.mdot - (rho_SC*A_flow*der(L_sc)) - (A_flow*L_sc*K_sc*der(P_stm.P)); // Flow rate out of subcooled domain
       m_dot_B = (h_wb*(N_tubes*pi*D_outer*L_b)*(T_TN3*0.5 + T_TN4*0.5 - T_sat))/(X_4 + K_4*P_stm.P); // Flow rate out of boiling domain
-    //  m_dot_SC = 1.925004320027648e+02;
-    //  m_dot_B = 1.925004320027648e+02;
+//  m_dot_SC = 1.925004320027648e+02;
+//  m_dot_B = 1.925004320027648e+02;
       der(M_sh) = m_dot_B - m_dot_SH.mdot; // Rate of steam mass change
       P_OTSG_Primary = m_dot_hitec*cP_hitec*(T_in_hitec_OTSG.T - T_PN6);
     annotation(
@@ -981,7 +981,7 @@ package MCFR_HyS_BOP
         H_vRH = Water.specificEnthalpy_pT(P_HP.P*1e6, T_OTSG.T + 273.15)/1e6 - Q_RH/m_dot_vRH;
         T_vRH = Water.temperature_ph(P_HP.P*1e6, H_vRH*1e6) - 273.15;
     end if;
-    //Explanation: The limits of the reheater are that the reheated outlet can be heated nearly to the temp of the valve side inlet, or the valve side outlet can be cooled nearly down to the temp of the regeated side inlet. The reheated side cannot be heated beyond the valve side max temp nor can the valve side transfer heat when below the secondary side's minimum temp due to Newton's law of cooling.
+//Explanation: The limits of the reheater are that the reheated outlet can be heated nearly to the temp of the valve side inlet, or the valve side outlet can be cooled nearly down to the temp of the regeated side inlet. The reheated side cannot be heated beyond the valve side max temp nor can the valve side transfer heat when below the secondary side's minimum temp due to Newton's law of cooling.
 //======================
 //LOW PRESSURE TURBINE EQNS:
        m_dot_LPT_in = m_dot_RH;
@@ -1088,7 +1088,7 @@ package MCFR_HyS_BOP
       parameter MCFR_HyS_BOP.Units.Volt E0_cell = 0.6;// From Gorensek
       parameter MCFR_HyS_BOP.Units.WeightPercent WtP_SA_nom = 0.9;
       parameter MCFR_HyS_BOP.Units.MolFlowRate Mdot_H2O_nom;//Nominal excess water flow rate
-      parameter MCFR_HyS_BOP.Units.MolFlowRate Mdot_SA_nom;    //Nominal net sulfur flow rate
+      parameter MCFR_HyS_BOP.Units.MolFlowRate Mdot_SA_nom;          //Nominal net sulfur flow rate
       // ~~~
       parameter MCFR_HyS_BOP.Units.Time rampstart;
       parameter MCFR_HyS_BOP.Units.Number ramp_min;
@@ -1470,6 +1470,8 @@ end HyS;
     type Conversion = Real(unit = "1", min = 0, max = 1);
     type StandardEntropy = Real(unit = "MJ/(mol*K)");
     type EnthalpyOfReaction = Real(unit = "MJ/mol");
+
+    type ReactivityRate = Real(unit = "1/s");
     
     
   end Units;
@@ -1567,12 +1569,12 @@ end HyS;
 
   model notes
   equation
-  // ===== Misc =====
-  // Errors/warnings at the start of a simulation are due to variables settling into steady state after initialization. Transients should thus begin a few thousand seconds in.
-  // Hard crashes of the model are often due to the OTSG. As is, the model cannot handle when the superheated steam domain length goes to zero. That happens when the temperatures in the OTSG go too low for too long. Improvement of the OTSG in this regard means that saturated steam is allowed through. Adjustments would possibly be needed in the RBOP too.
+// ===== Misc =====
+// Errors/warnings at the start of a simulation are due to variables settling into steady state after initialization. Transients should thus begin a few thousand seconds in.
+// Hard crashes of the model are often due to the OTSG. As is, the model cannot handle when the superheated steam domain length goes to zero. That happens when the temperatures in the OTSG go too low for too long. Improvement of the OTSG in this regard means that saturated steam is allowed through. Adjustments would possibly be needed in the RBOP too.
 // ===== Organization =====
-  //// The "Simbase" class is what connects all the modules/components together. It has the values for the parameters that are most important and/or most likely to be changed to simulate different transients.
-  //// The "Nuclear" package has the modules necessary to model the reactor and give it improved capabilities/features. These include modified point kinetics (mPKE) for tracking neutron population, DecayHeat for tracking decay heat via precursor groups (similar to delayed neutrons), Poisons for tracking poison and poison parent concentrations, and ReactivityFeedback for determining all feedbacks and producing a net reactivity value for mPKE.
+//// The "Simbase" class is what connects all the modules/components together. It has the values for the parameters that are most important and/or most likely to be changed to simulate different transients.
+//// The "Nuclear" package has the modules necessary to model the reactor and give it improved capabilities/features. These include modified point kinetics (mPKE) for tracking neutron population, DecayHeat for tracking decay heat via precursor groups (similar to delayed neutrons), Poisons for tracking poison and poison parent concentrations, and ReactivityFeedback for determining all feedbacks and producing a net reactivity value for mPKE.
 //// The "HeatTransport" package has all the components of the IES. These include the MCFR Core, the eight primary heat exchangers (which are combined as one component), the secondary heat exchanger (also called the Thermal Manifold), the Once-Through Steam Generator (OTSG), Rankine Balance of Plant (RBOP), and hybrid sulfur cycle (HyS). The RBOP and HyS are not purely heat exchangers, have interdepencies with their components, and thus are grouped into their own model class script in this organization. The 'Water' and 'MoistAir' packages are necessary for the RBOP to function. The Ultimate Heat Exchanger (UHX) is a simple heat removal component that is not used by default but was used for debugging.
 //// The "Pumps" package has the modules for each of the main salt loops (primary, secondary, and tertiary). These are simple and only determine the flow fraction when the pump is tripped. By default, they output the flow fraction as 1.
 //// The "Units" package lists and defines each of the units used throughout the model.

--- a/MCFR_HyS_BOP.mo
+++ b/MCFR_HyS_BOP.mo
@@ -775,8 +775,7 @@ package MCFR_HyS_BOP
       L_b = L_b_initial;
       L_sh = L_sh_initial;
       P_stm.P = P_setpoint;
-      rho_SH1 = Water.density_pT(P_stm.P*1e6, T_SH1.T + 273.15);
-      M_sh = A_flow * rho_SH1 * L_sh_initial;
+      M_sh = A_flow * Water.density_pT(P_stm.P*1e6, T_SH1.T + 273.15) * L_sh_initial;
     equation
       fdw = Water.setState_pT(P_stm.P*1e6, T_fdw.T + 273.15);
       SC2 = Water.setState_pT(P_stm.P*1e6, T_SC2 + 273.15);
@@ -1041,7 +1040,7 @@ package MCFR_HyS_BOP
 //FEEDWATER HEATER EQNS:
 //   m_dot_fdw.mdot = m_dot_fdw_nom;//388.963;//(m_dot_HPT_bleed + m_dot_LPT_bleed + m_dot_liq + m_dot_vRH + m_dot_con);
        m_dot_fdw2 = (m_dot_HPT_bleed + m_dot_LPT_bleed + m_dot_liq + m_dot_vRH + m_dot_con);
-       m_dot_fdw.mdot = m_dot_fdw_nom + delay(sinmag*m_dot_fdw_nom*sin(omega*time),sinstart);//(if (time < rampstart) then 0 else if (time < rampstart + 500) then -(m_dot_fdw_nom*(1-ramp_min))*(time - rampstart)/500 else if (time < rampstart + 1500) then -(m_dot_fdw_nom*(1-ramp_min)) else if (time < rampstart + 2000) then -(m_dot_fdw_nom*(1-ramp_min))*(rampstart + 2000 - time)/500 else 0);
+       m_dot_fdw.mdot = (m_dot_fdw_nom + delay(sinmag*m_dot_fdw_nom*sin(omega*time),sinstart)) * (if (time < rampstart) then (1) else if (time < rampstart + 500) then (1 - (1-ramp_min) * (time - rampstart)/500) else if (time < rampstart + 1500) then (ramp_min) else if (time < rampstart + 2000) then (1 - (1-ramp_min) * (2000 + rampstart - time)/500) else (1));
        H_setpoint = Water.specificEnthalpy_pT(P_HP.P*1e6, T_setpoint + 273.15)/1e6;
        K_LPB_check = (m_dot_fdw.mdot/(H_LPT_bleed*m_dot_LPT_in))*(H_setpoint - ((H_HPT_bleed*m_dot_HPT_bleed/m_dot_fdw.mdot) + (H_f_MS*m_dot_liq/m_dot_fdw.mdot) + (H_vRH*m_dot_vRH/m_dot_fdw.mdot) + (H_con_out*m_dot_con/m_dot_fdw.mdot)));
     if K_LPB_check > 0 then
@@ -1254,8 +1253,8 @@ package MCFR_HyS_BOP
       delta_T_cond = T_vap - T_elec;
 // ============
 // Mass Balance
-      Mdot_H2O_Eout = Mdot_H2O_nom + delay(sinmag*Mdot_H2O_nom*sin(omega*time),sinstart) + (if (time < rampstart) then 0 else if (time < rampstart + 500) then -(Mdot_H2O_nom*(1-ramp_min))*(time - rampstart)/500 else if (time < rampstart + 1500) then -(Mdot_H2O_nom*(1-ramp_min)) else if (time < rampstart + 2000) then -(Mdot_H2O_nom*(1-ramp_min))*(rampstart + 2000 - time)/500 else 0);
-      Mdot_SA_in = Mdot_SA_nom * ((1 - 0.01)*exp(-0.092*delay(time, sulfouttime)) + 0.01);
+      Mdot_H2O_Eout = (Mdot_H2O_nom + delay(sinmag*Mdot_H2O_nom*sin(omega*time),sinstart))* (if (time < rampstart) then (1) else if (time < rampstart + 500) then (1 - (1-ramp_min) * (time - rampstart)/500) else if (time < rampstart + 1500) then (ramp_min) else if (time < rampstart + 2000) then (1 - (1-ramp_min) * (2000 + rampstart - time)/500) else (1));
+      Mdot_SA_in = (Mdot_SA_nom * ((1 - 0.01)*exp(-0.092*delay(time, sulfouttime)) + 0.01)) * (if (time < rampstart) then (1) else if (time < rampstart + 500) then (1 - (1-ramp_min) * (time - rampstart)/500) else if (time < rampstart + 1500) then (ramp_min) else if (time < rampstart + 2000) then (1 - (1-ramp_min) * (2000 + rampstart - time)/500) else (1));
 // ~~~
       mdot_H = mdot_H_nom*FF_HyS_Hot.FF;//Hot salt flow rate
       mdot_S = Mdot_SA_in*MM_SA + Mdot_H2O_Eout*MM_H2O;


### PR DESCRIPTION
In `MCFR_HyS_BOP.ReactivityFeedback`, the variable `ReactExternalRamp` was redefigned so that the value was calculated from the parameters `ramp_rate` and `ramp_mag`. `ramp_rate` had its units changed to a new `ReactivityRate` type with units "1/s" and `ramp_mag` replaces the unused `ramp_low` and has units of "1".